### PR TITLE
add 80211_get_mode; bugfix attrs memset

### DIFF
--- a/include/nanonl/nl_80211.h
+++ b/include/nanonl/nl_80211.h
@@ -134,6 +134,15 @@ int nl_80211_regdomain_reload(struct nl_80211_ctx *ctx);
 int nl_80211_set_mode(struct nl_80211_ctx *ctx, const char *iface, enum nl80211_iftype mode);
 
 /**
+ * \brief Get interface mode
+ * \param[in] ctx       nl80211 context.
+ * \param[in] iface     network interface.
+ * \param[out] mode     interface mode.
+ * \return 0 on success, non-zero on error.
+ */
+int nl_80211_get_mode(struct nl_80211_ctx *ctx, const char *iface, enum nl80211_iftype *mode);
+
+/**
  * \brief Set interface power mode
  * \param[in] ctx       nl80211 context.
  * \param[in] iface     network interface.


### PR DESCRIPTION
Add `nl_80211_get_mode()` to complement set_mode.  I copied the code from get_freq, which turned out to have a bug because attrs wasn't `memset()` before use.  In upstream code, example use of gen attrs shows use of memset.  I was getting random answers and segfaults for calls to get_freq/get_channel otherwise.